### PR TITLE
Correct 4.1.15 sudo audit syntax

### DIFF
--- a/templates/audit/99_auditd.rules.j2
+++ b/templates/audit/99_auditd.rules.j2
@@ -66,8 +66,8 @@
 -w /etc/sudoers.d/ -p wa -k scope
 {% endif %}
 {% if amazon2cis_rule_4_1_15 %}
--a always,exit -F arch=b64 -C euid!=uid -F euid=0 -Fauid>=1000 -F auid!=4294967295 -S execve -k actions
--a always,exit -F arch=b32 -C euid!=uid -F euid=0 -Fauid>=1000 -F auid!=4294967295 -S execve -k actions
+-a always,exit -F arch=b64 -C euid!=uid -F euid=0 -F auid>=1000 -F auid!=4294967295 -S execve -k actions
+-a always,exit -F arch=b32 -C euid!=uid -F euid=0 -F auid>=1000 -F auid!=4294967295 -S execve -k actions
 {% endif %}
 {% if amazon2cis_rule_4_1_16 %}
 -w /sbin/insmod -p x -k modules


### PR DESCRIPTION
**Overall Review of Changes:**
Add a missing space in `-F auid`

**How has this been tested?:**
We have run it against an Amazon Linux 2 EC2 instance and then ran the AMAZON2-CIS-Audit repo tests against it.

